### PR TITLE
OT-375

### DIFF
--- a/_devel/ci/build-in-container-gcc.sh
+++ b/_devel/ci/build-in-container-gcc.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
+time \
 docker run \
     --mount type=bind,src=/mnt/f/repo-matterfi/opentxs,dst=/home/src,readonly \
     --mount type=bind,src=/home/pgawron/opentxs/output,dst=/home/output \
     -i --entrypoint /usr/bin/build-opentxs-gcc.sh \
-    polishcode/matterfi-ci-fedora:35-1 test01
+    polishcode/matterfi-ci-fedora:35-2 full ccov

--- a/_devel/ci/ccov-in-container-gcc.sh
+++ b/_devel/ci/ccov-in-container-gcc.sh
@@ -4,5 +4,6 @@ time \
 docker run \
     --mount type=bind,src=/mnt/f/repo-matterfi/opentxs,dst=/home/src,readonly \
     --mount type=bind,src=/home/pgawron/opentxs/output,dst=/home/output \
-    -i --entrypoint /usr/bin/build-opentxs-clang.sh \
-    polishcode/matterfi-ci-fedora:35-2 full no-ccov
+    --mount type=bind,src=/mnt/f/temp/opentxs-coverage,dst=/home/coverage \
+    -i --entrypoint /usr/bin/ccov-opentxs-gcc.sh \
+    polishcode/matterfi-ci-fedora:35-2

--- a/_devel/ci/run-container.sh
+++ b/_devel/ci/run-container.sh
@@ -4,6 +4,7 @@ docker run \
     -it \
     --mount type=bind,src=/mnt/f/repo-matterfi/opentxs,dst=/home/src,readonly \
     --mount type=bind,src=/mnt/f/repo-matterfi/docker/_devel/ci,dst=/home/script,readonly \
+    --mount type=bind,src=/mnt/f/temp/opentxs-coverage,dst=/home/coverage \
     --mount type=bind,src=/home/pgawron/opentxs/output,dst=/home/output \
     --workdir=/home/script \
-    polishcode/matterfi-ci-fedora:35-1
+    polishcode/matterfi-ci-fedora:35-2

--- a/_devel/ci/test-in-container.sh
+++ b/_devel/ci/test-in-container.sh
@@ -4,4 +4,4 @@ docker run \
     --mount type=bind,src=/mnt/f/repo-matterfi/opentxs,dst=/home/src,readonly \
     --mount type=bind,src=/home/pgawron/opentxs/output,dst=/home/output \
     -i --entrypoint /usr/bin/test-opentxs.sh \
-    polishcode/matterfi-ci-fedora:35-1 test01
+    polishcode/matterfi-ci-fedora:35-2 "-R ottest-blockchain-address"

--- a/ci/Dockerfile-fedora-35
+++ b/ci/Dockerfile-fedora-35
@@ -32,6 +32,13 @@ RUN dnf --nodocs install -y --setopt=install_weak_deps=False \
     sqlite-devel \
     which \
     zeromq-devel \
+    compiler-rt.x86_64 \
+    tree \
+    findutils \
+    gcovr \
+    nano \
+    cargo \
+    spdlog \
     && rm -rf /var/cache/dnf
 
 FROM fedora-download AS gtest-download
@@ -250,12 +257,15 @@ COPY --from=fedora-cmake /usr/local /usr/local
 COPY --from=fedora-qt /usr/local /usr/local
 COPY --from=fedora-opendht /usr/local /usr/local
 RUN ldconfig
-COPY ./build-opentxs.sh /usr/bin
-COPY ./build-opentxs-clang.sh /usr/bin
-COPY ./build-opentxs-gcc.sh /usr/bin
-COPY ./test-opentxs.sh /usr/bin
-COPY ./opentxs-config.sh /var/lib
+COPY ./build-opentxs.sh         /usr/bin
+COPY ./build-opentxs-clang.sh   /usr/bin
+COPY ./build-opentxs-gcc.sh     /usr/bin
+COPY ./ccov-opentxs-gcc.sh      /usr/bin
+COPY ./test-opentxs.sh          /usr/bin
+COPY ./opentxs-config.sh        /var/lib
+COPY ./opentxs-prologue.sh      /var/lib
 RUN chmod a+x /usr/bin/build-opentxs.sh
 RUN chmod a+x /usr/bin/build-opentxs-clang.sh
 RUN chmod a+x /usr/bin/build-opentxs-gcc.sh
+RUN chmod a+x /usr/bin/ccov-opentxs-gcc.sh
 RUN chmod a+x /usr/bin/test-opentxs.sh

--- a/ci/README.md
+++ b/ci/README.md
@@ -11,7 +11,7 @@ docker image build -t opentransactions/ci:10 .
 docker image build -t polishcode/matterfi-ci-fedora:32-1 .
 docker image build -t polishcode/matterfi-ci-fedora:33-1 -f Dockerfile-fedora-33 .
 docker image build -t polishcode/matterfi-ci-fedora:34-1 -f Dockerfile-fedora-34 .
-docker image build -t polishcode/matterfi-ci-fedora:35-1 -f Dockerfile-fedora-35 .
+docker image build -t polishcode/matterfi-ci-fedora:35-2 -f Dockerfile-fedora-35 .
 docker image build -t polishcode/matterfi-ci-fedora:36-1 -f Dockerfile-fedora-36 .
 ```
 

--- a/ci/build-opentxs-clang.sh
+++ b/ci/build-opentxs-clang.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-/usr/bin/build-opentxs.sh /usr/bin/clang /usr/bin/clang++ "${1}"
+/usr/bin/build-opentxs.sh /usr/bin/clang /usr/bin/clang++ "${1}" "${2}"

--- a/ci/build-opentxs-gcc.sh
+++ b/ci/build-opentxs-gcc.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-/usr/bin/build-opentxs.sh /usr/bin/gcc /usr/bin/g++ "${1}"
+/usr/bin/build-opentxs.sh /usr/bin/gcc /usr/bin/g++ "${1}" "${2}"

--- a/ci/build-opentxs.sh
+++ b/ci/build-opentxs.sh
@@ -1,19 +1,12 @@
 #!/bin/bash
 
+#make sure we have prerequisites
+source /var/lib/opentxs-prologue.sh
+
 C_COMPILER="${1}"
 CXX_COMPILER="${2}"
-SRC="/home/src"
-WORK="/home/output"
-
-if [ ! -d "${SRC}" ]; then
-    echo "Source tree missing. Mount opentxs source directory at ${SRC}"
-    exit 1
-fi
-
-if [ ! -d "${WORK}" ]; then
-    echo "Work directory missing. Mount build directory at ${WORK}"
-    exit 1
-fi
+#${3} specifies build type
+CODE_COVERAGE="${4}"
 
 if [ "${C_COMPILER}" == "" ]; then
     echo "C compiler not set"
@@ -25,9 +18,28 @@ if [ "${CXX_COMPILER}" == "" ]; then
     exit 1
 fi
 
-set -e
+#code coverage setting needs to be explicitly defined: ccov or no-ccov
+if ! [[ "${CODE_COVERAGE}" =~ ^(ccov|no-ccov)$ ]]; then
+    echo "-- code coverage/no code coverage parameter not defined"
+    exit 1
+fi
+#enable code coverage
+#TODO works only with gcc
+if [ "${CODE_COVERAGE}" == "ccov" ]; then
+    echo "-- code coverage enabled"
+
+    #clang - TODO
+    #builds, but cannot use gcovr to generate a report; for now gcc should be more than enough
+    #export OT_CMAKE_C_FLAGS="-fprofile-instr-generate -fcoverage-mapping"
+
+    #gcc - assumes we are building for gcc, option clang + ccov will fail, but this is fine
+    #https://gcovr.com/en/stable/guide/compiling.html#compiler-options
+    export OT_CMAKE_C_FLAGS="-fprofile-arcs -ftest-coverage -O1 -fprofile-abs-path"
+fi
+
 git config --global --add safe.directory "${SRC}"  #https://stackoverflow.com/a/71941707
 source /var/lib/opentxs-config.sh "${3}"
+
 rm -rf "${WORK}/"*
 cd "${WORK}"
 /usr/local/bin/cmake \
@@ -35,6 +47,8 @@ cd "${WORK}"
     -DCMAKE_C_COMPILER="${C_COMPILER}" \
     -DCMAKE_CXX_COMPILER="${CXX_COMPILER}" \
     -DCMAKE_BUILD_TYPE=Debug \
+    -DCMAKE_C_FLAGS="${OT_CMAKE_C_FLAGS}" \
+    -DCMAKE_CXX_FLAGS="${OT_CMAKE_C_FLAGS}" \
     -DBUILD_SHARED_LIBS=ON \
     -DOT_LUCRE_DEBUG=OFF \
     ${OT_OPTIONS} \

--- a/ci/ccov-opentxs-gcc.sh
+++ b/ci/ccov-opentxs-gcc.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+#make sure we have prerequisites
+source /var/lib/opentxs-prologue.sh
+
+export CCOV="/home/coverage"
+
+if [ ! -d "${CCOV}" ]; then
+    echo "Code coverage directory missing. Initialize at ${CCOV}"
+    exit 1
+fi
+
+gcovr --version
+gcovr   -r "${SRC}" \
+        -j 16 \
+        -e "${SRC}"/src/serialization \
+        -e "${SRC}"/deps \
+        -e "${SRC}"/tests \
+        --html-details "${CCOV}"/coverage.html \
+        --print-summary \
+        "${WORK}"

--- a/ci/opentxs-prologue.sh
+++ b/ci/opentxs-prologue.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+#exit immediately if sth goes wrong
+set -e
+
+export SRC="/home/src"
+export WORK="/home/output"
+
+if [ ! -d "${SRC}" ]; then
+    echo "Source tree missing. Mount opentxs source directory at ${SRC}"
+    exit 1
+fi
+
+if [ ! -d "${WORK}" ]; then
+    echo "Work directory missing. Mount build directory at ${WORK}"
+    exit 1
+fi

--- a/ci/test-opentxs.sh
+++ b/ci/test-opentxs.sh
@@ -1,26 +1,15 @@
 #!/bin/bash
 
+#make sure we have prerequisites
+source /var/lib/opentxs-prologue.sh
+
 #e.g. "-j 10 --output-on-failure --repeat until-pass:5 --timeout 300 --schedule-random"
 CTEST_PARAMS="${1}"
-SRC="/home/src"
-WORK="/home/output"
-
-if [ ! -d "${SRC}" ]; then
-    echo "Source tree missing. Mount opentxs source directory at ${SRC}"
-    exit 1
-fi
-
-if [ ! -d "${WORK}" ]; then
-    echo "Work directory missing. Mount build directory at ${WORK}"
-    exit 1
-fi
 
 if [ "${CTEST_PARAMS}" == "" ]; then
     echo "ctest params not set"
     exit 1
 fi
-
-set -e
 
 cd "${WORK}"
 


### PR DESCRIPTION
- introduced code coverage functionality - for gcc
- updated development scripts
- updated fedora 35 docker image to support code coverage
- introduced ccov/no-ccov build parameter
- refactored build scripts - introduced common prologue
- introduced ccov calculation script
- added ccov compiler flags