### PR TITLE
OT-377 added support for clang sanitizer build

### DIFF
--- a/_devel/ci/build-in-container-clang-sanitizer.sh
+++ b/_devel/ci/build-in-container-clang-sanitizer.sh
@@ -4,6 +4,5 @@ time \
 docker run \
     --mount type=bind,src=/mnt/f/repo-matterfi/opentxs,dst=/home/src,readonly \
     --mount type=bind,src=/home/pgawron/opentxs/output,dst=/home/output \
-    --mount type=bind,src=/mnt/f/temp/opentxs-coverage,dst=/home/coverage \
-    -i --entrypoint /usr/bin/ccov-opentxs-gcc.sh \
-    polishcode/matterfi-ci-fedora:35-3
+    -i --entrypoint /usr/bin/build-opentxs-clang.sh \
+    polishcode/matterfi-ci-fedora:35-3 full sanitizer

--- a/_devel/ci/build-in-container-clang.sh
+++ b/_devel/ci/build-in-container-clang.sh
@@ -5,4 +5,4 @@ docker run \
     --mount type=bind,src=/mnt/f/repo-matterfi/opentxs,dst=/home/src,readonly \
     --mount type=bind,src=/home/pgawron/opentxs/output,dst=/home/output \
     -i --entrypoint /usr/bin/build-opentxs-clang.sh \
-    polishcode/matterfi-ci-fedora:35-2 full no-ccov
+    polishcode/matterfi-ci-fedora:35-3 full standard

--- a/_devel/ci/build-in-container-gcc-ccov.sh
+++ b/_devel/ci/build-in-container-gcc-ccov.sh
@@ -4,6 +4,5 @@ time \
 docker run \
     --mount type=bind,src=/mnt/f/repo-matterfi/opentxs,dst=/home/src,readonly \
     --mount type=bind,src=/home/pgawron/opentxs/output,dst=/home/output \
-    --mount type=bind,src=/mnt/f/temp/opentxs-coverage,dst=/home/coverage \
-    -i --entrypoint /usr/bin/ccov-opentxs-gcc.sh \
-    polishcode/matterfi-ci-fedora:35-3
+    -i --entrypoint /usr/bin/build-opentxs-gcc.sh \
+    polishcode/matterfi-ci-fedora:35-3 full ccov

--- a/_devel/ci/build-in-container-gcc.sh
+++ b/_devel/ci/build-in-container-gcc.sh
@@ -5,4 +5,4 @@ docker run \
     --mount type=bind,src=/mnt/f/repo-matterfi/opentxs,dst=/home/src,readonly \
     --mount type=bind,src=/home/pgawron/opentxs/output,dst=/home/output \
     -i --entrypoint /usr/bin/build-opentxs-gcc.sh \
-    polishcode/matterfi-ci-fedora:35-2 full ccov
+    polishcode/matterfi-ci-fedora:35-3 full standard

--- a/_devel/ci/run-container.sh
+++ b/_devel/ci/run-container.sh
@@ -7,4 +7,4 @@ docker run \
     --mount type=bind,src=/mnt/f/temp/opentxs-coverage,dst=/home/coverage \
     --mount type=bind,src=/home/pgawron/opentxs/output,dst=/home/output \
     --workdir=/home/script \
-    polishcode/matterfi-ci-fedora:35-2
+    polishcode/matterfi-ci-fedora:35-3

--- a/_devel/ci/test-in-container.sh
+++ b/_devel/ci/test-in-container.sh
@@ -4,4 +4,4 @@ docker run \
     --mount type=bind,src=/mnt/f/repo-matterfi/opentxs,dst=/home/src,readonly \
     --mount type=bind,src=/home/pgawron/opentxs/output,dst=/home/output \
     -i --entrypoint /usr/bin/test-opentxs.sh \
-    polishcode/matterfi-ci-fedora:35-2 "-R ottest-blockchain-address"
+    polishcode/matterfi-ci-fedora:35-3 "-V -R ottest-blockchain-address"

--- a/ci/README.md
+++ b/ci/README.md
@@ -11,7 +11,7 @@ docker image build -t opentransactions/ci:10 .
 docker image build -t polishcode/matterfi-ci-fedora:32-1 .
 docker image build -t polishcode/matterfi-ci-fedora:33-1 -f Dockerfile-fedora-33 .
 docker image build -t polishcode/matterfi-ci-fedora:34-1 -f Dockerfile-fedora-34 .
-docker image build -t polishcode/matterfi-ci-fedora:35-2 -f Dockerfile-fedora-35 .
+docker image build -t polishcode/matterfi-ci-fedora:35-3 -f Dockerfile-fedora-35 .
 docker image build -t polishcode/matterfi-ci-fedora:36-1 -f Dockerfile-fedora-36 .
 ```
 

--- a/ci/build-opentxs.sh
+++ b/ci/build-opentxs.sh
@@ -6,26 +6,30 @@ source /var/lib/opentxs-prologue.sh
 C_COMPILER="${1}"
 CXX_COMPILER="${2}"
 #${3} specifies build type
-CODE_COVERAGE="${4}"
+BUILD_MODE="${4}"
 
 if [ "${C_COMPILER}" == "" ]; then
     echo "C compiler not set"
     exit 1
 fi
-
 if [ "${CXX_COMPILER}" == "" ]; then
     echo "C++ compiler not set"
     exit 1
 fi
-
-#code coverage setting needs to be explicitly defined: ccov or no-ccov
-if ! [[ "${CODE_COVERAGE}" =~ ^(ccov|no-ccov)$ ]]; then
-    echo "-- code coverage/no code coverage parameter not defined"
+if [ "${BUILD_MODE}" == "" ]; then
+    echo "build mode not set"
     exit 1
 fi
-#enable code coverage
-#TODO works only with gcc
-if [ "${CODE_COVERAGE}" == "ccov" ]; then
+
+#build mode setting needs to be explicitly defined:
+# standard 
+# ccov      - gcc only, for calculating code coverage statistics
+# sanitizer - clang only, for running under sanitizer
+if ! [[ "${BUILD_MODE}" =~ ^(standard|ccov|sanitizer)$ ]]; then
+    echo "-- build mode parameter not defined [standard|ccov|sanitizer]"
+    exit 1
+fi
+if [ "${BUILD_MODE}" == "ccov" ]; then
     echo "-- code coverage enabled"
 
     #clang - TODO
@@ -35,6 +39,16 @@ if [ "${CODE_COVERAGE}" == "ccov" ]; then
     #gcc - assumes we are building for gcc, option clang + ccov will fail, but this is fine
     #https://gcovr.com/en/stable/guide/compiling.html#compiler-options
     export OT_CMAKE_C_FLAGS="-fprofile-arcs -ftest-coverage -O1 -fprofile-abs-path"
+fi
+if [ "${BUILD_MODE}" == "sanitizer" ]; then
+    echo "-- sanitizer enabled"
+
+    #clang-only
+    export OT_OPTIMIZE="-O1"
+    export OT_CMAKE_C_FLAGS="-fno-omit-frame-pointer -fno-optimize-sibling-calls -fsanitize=address,undefined,leak -fsanitize-address-use-after-scope -fno-sanitize-recover=all -fsanitize-recover=implicit-conversion -fsanitize-recover=signed-integer-overflow"
+    export OT_CMAKE_CXX_FLAGS="-fno-sanitize=vptr"
+    export OT_CMAKE_EXE_LINKER_FLAGS="-fsanitize=address,undefined,leak"
+    export ASAN_OPTIONS="detect_container_overflow=0"
 fi
 
 git config --global --add safe.directory "${SRC}"  #https://stackoverflow.com/a/71941707
@@ -47,8 +61,9 @@ cd "${WORK}"
     -DCMAKE_C_COMPILER="${C_COMPILER}" \
     -DCMAKE_CXX_COMPILER="${CXX_COMPILER}" \
     -DCMAKE_BUILD_TYPE=Debug \
-    -DCMAKE_C_FLAGS="${OT_CMAKE_C_FLAGS}" \
-    -DCMAKE_CXX_FLAGS="${OT_CMAKE_C_FLAGS}" \
+    -DCMAKE_C_FLAGS="${OT_OPTIMIZE} ${OT_CMAKE_C_FLAGS}" \
+    -DCMAKE_CXX_FLAGS="${OT_OPTIMIZE} ${OT_CMAKE_C_FLAGS} ${OT_CMAKE_CXX_FLAGS}" \
+    -DCMAKE_EXE_LINKER_FLAGS="${OT_CMAKE_EXE_LINKER_FLAGS}" \
     -DBUILD_SHARED_LIBS=ON \
     -DOT_LUCRE_DEBUG=OFF \
     ${OT_OPTIONS} \

--- a/ci/test-opentxs.sh
+++ b/ci/test-opentxs.sh
@@ -13,6 +13,5 @@ fi
 
 cd "${WORK}"
 
-echo ${CTEST_PARAMS}
-#cmake --install .  #no need to install
+echo "-- ctest params: " ${CTEST_PARAMS}
 ctest ${CTEST_PARAMS}


### PR DESCRIPTION
- introduced build modes: standard, ccov, sanitizer
- added new ci docker image (35-3)
- test script runs ctest verbose
- clang supports standard + sanitizer
- gcc supports standard + ccov
- new client scripts