### PR TITLE
OT-379 added support for clang tidy build

### DIFF
--- a/_devel/ci/build-in-container-clang-tidy.sh
+++ b/_devel/ci/build-in-container-clang-tidy.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+time \
+docker run \
+    --mount type=bind,src=/mnt/f/repo-matterfi/opentxs,dst=/home/src,readonly \
+    --mount type=bind,src=/home/pgawron/opentxs/output,dst=/home/output \
+    -i --entrypoint /usr/bin/build-opentxs-clang.sh \
+    polishcode/matterfi-ci-fedora:36-tidy-1 tidy standard

--- a/_devel/ci/run-container.sh
+++ b/_devel/ci/run-container.sh
@@ -7,4 +7,4 @@ docker run \
     --mount type=bind,src=/mnt/f/temp/opentxs-coverage,dst=/home/coverage \
     --mount type=bind,src=/home/pgawron/opentxs/output,dst=/home/output \
     --workdir=/home/script \
-    polishcode/matterfi-ci-fedora:35-3
+    polishcode/matterfi-ci-fedora:36-tidy-1

--- a/ci/Dockerfile-fedora-36-tidy
+++ b/ci/Dockerfile-fedora-36-tidy
@@ -1,0 +1,135 @@
+FROM fedora:36 AS fedora-base
+
+FROM fedora-base AS fedora-download
+RUN dnf --nodocs install -y --setopt=install_weak_deps=False \
+    git bzip2 lzo p7zip wget xz \
+    && rm -rf /var/cache/dnf
+
+FROM fedora-base AS fedora-build
+RUN dnf --nodocs install -y --setopt=install_weak_deps=False \
+    clang \
+    clang-analyzer \
+    clang-tools-extra \
+    cmake \
+    cppcheck \
+    gcc \
+    gcc-c++ \
+    git \
+    gmock-devel \
+    gnutls-devel \
+    gtest-devel \
+    harfbuzz \
+    libargon2-devel \
+    libicu \
+    libpng \
+    libsodium-devel \
+    llvm \
+    lmdb-devel \
+    mesa-libGL \
+    mesa-libOSMesa \
+    msgpack-devel \
+    ninja-build \
+    openssl-devel \
+    protobuf-compiler \
+    protobuf-lite-devel \
+    qt6-qtdeclarative-devel \
+    sqlite-devel \
+    which \
+    zeromq-devel \
+    && rm -rf /var/cache/dnf
+
+FROM fedora-download AS iwyu-download
+ARG IWYU_BRANCH="clang_14"
+RUN mkdir -p /usr/src \
+    && git clone --recursive "https://github.com/include-what-you-use/include-what-you-use" /usr/src/iwyu \
+    && cd /usr/src/iwyu \
+    && git checkout "${IWYU_BRANCH}"
+
+FROM fedora-download AS boost-download
+ARG BOOST_MAJOR="1"
+ARG BOOST_MINOR="79"
+ARG BOOST_PATCH="0"
+RUN mkdir -p /usr/src \
+    && wget -O /usr/src/boost.tar.bz2 "https://boostorg.jfrog.io/artifactory/main/release/${BOOST_MAJOR}.${BOOST_MINOR}.${BOOST_PATCH}/source/boost_${BOOST_MAJOR}_${BOOST_MINOR}_${BOOST_PATCH}.tar.bz2" \
+    && tar -xf /usr/src/boost.tar.bz2 -C /usr/src \
+    && rm /usr/src/boost.tar.bz2 \
+    && mv "/usr/src/boost_${BOOST_MAJOR}_${BOOST_MINOR}_${BOOST_PATCH}" /usr/src/boost
+
+FROM fedora-download AS cmake-download
+ARG CMAKE_VERSION="3.23.2"
+RUN mkdir -p /usr/src \
+    && cd /usr/src \
+    && wget -O /usr/src/cmake.tar.gz "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}.tar.gz" \
+    && tar -xf cmake.tar.gz \
+    && rm cmake.tar.gz \
+    && mv "cmake-${CMAKE_VERSION}" cmake
+FROM fedora-download AS opendht-download
+ARG OPENDHT_TAG="v2.4.9"
+RUN mkdir -p /usr/src \
+    && git clone --recursive "https://github.com/savoirfairelinux/opendht" /usr/src/opendht \
+    && cd /usr/src/opendht \
+    && git checkout "${OPENDHT_TAG}"
+
+FROM fedora-build AS fedora-iwyu
+RUN dnf --nodocs install -y --setopt=install_weak_deps=False \
+    clang-devel llvm-devel \
+    && rm -rf /var/cache/dnf
+COPY --from=iwyu-download /usr/src/iwyu /usr/src/iwyu
+RUN mkdir -p /tmp/iwyu && cd /tmp/iwyu \
+    && cmake -GNinja /usr/src/iwyu \
+    && cmake --build . \
+    && cmake --install . \
+    && rm -rf /tmp/iwyu
+
+FROM fedora-build AS fedora-boost
+COPY --from=boost-download /usr/src/boost /usr/src/boost
+RUN cd /usr/src/boost \
+    && ./bootstrap.sh --prefix=/usr/local --with-libraries=all \
+    && ./b2 \
+    && ./b2 install
+
+FROM fedora-build AS fedora-cmake
+COPY --from=cmake-download /usr/src/cmake /usr/src/cmake
+RUN mkdir -p /tmp/build \
+    && cd /tmp/build \
+    && cmake -GNinja /usr/src/cmake \
+    && cmake --build . \
+    && cmake --install .
+FROM fedora-build AS fedora-opendht
+RUN dnf --nodocs install -y --setopt=install_weak_deps=False \
+    libargon2-devel \
+    && rm -rf /var/cache/dnf
+COPY --from=opendht-download /usr/src/opendht /usr/src/opendht
+RUN mkdir -p /tmp/opendht && cd /tmp/opendht \
+    && cmake \
+        -GNinja \
+        -DOPENDHT_STATIC=OFF \
+        -DOPENDHT_LOG=OFF \
+        -DOPENDHT_TOOLS=OFF \
+        -DOPENDHT_PROXY_OPENSSL=OFF \
+        -DOPENDHT_PEER_DISCOVERY=OFF \
+        -DOPENDHT_TESTS_NETWORK=OFF \
+        -DOPENDHT_DOCUMENTATION=OFF \
+        /usr/src/opendht \
+    && cmake --build . \
+    && cmake --install . \
+    && rm -rf /tmp/opendht
+
+FROM fedora-build AS opentxs-fedora-ci
+COPY --from=fedora-iwyu /usr/local /usr
+COPY --from=fedora-boost /usr/local /usr/local
+COPY --from=fedora-cmake /usr/local /usr/local
+COPY --from=fedora-opendht /usr/local /usr/local
+RUN ldconfig
+COPY ./build-opentxs.sh         /usr/bin
+COPY ./build-opentxs-clang.sh   /usr/bin
+COPY ./build-opentxs-gcc.sh     /usr/bin
+COPY ./ccov-opentxs-gcc.sh      /usr/bin
+COPY ./test-opentxs.sh          /usr/bin
+COPY ./opentxs-config.sh        /var/lib
+COPY ./opentxs-prologue.sh      /var/lib
+RUN chmod a+x /usr/bin/build-opentxs.sh
+RUN chmod a+x /usr/bin/build-opentxs-clang.sh
+RUN chmod a+x /usr/bin/build-opentxs-gcc.sh
+RUN chmod a+x /usr/bin/ccov-opentxs-gcc.sh
+RUN chmod a+x /usr/bin/test-opentxs.sh

--- a/ci/README.md
+++ b/ci/README.md
@@ -9,10 +9,11 @@ These images construct build environments for compiling and testing Open-Transac
 ```
 docker image build -t opentransactions/ci:10 .
 docker image build -t polishcode/matterfi-ci-fedora:32-1 .
-docker image build -t polishcode/matterfi-ci-fedora:33-1 -f Dockerfile-fedora-33 .
-docker image build -t polishcode/matterfi-ci-fedora:34-1 -f Dockerfile-fedora-34 .
-docker image build -t polishcode/matterfi-ci-fedora:35-3 -f Dockerfile-fedora-35 .
-docker image build -t polishcode/matterfi-ci-fedora:36-1 -f Dockerfile-fedora-36 .
+docker image build -t polishcode/matterfi-ci-fedora:33-1      -f Dockerfile-fedora-33 .
+docker image build -t polishcode/matterfi-ci-fedora:34-1      -f Dockerfile-fedora-34 .
+docker image build -t polishcode/matterfi-ci-fedora:35-3      -f Dockerfile-fedora-35 .
+docker image build -t polishcode/matterfi-ci-fedora:36-1      -f Dockerfile-fedora-36 .
+docker image build -t polishcode/matterfi-ci-fedora:36-tidy-1 -f Dockerfile-fedora-36-tidy .
 ```
 
 ### Base Fedora version

--- a/ci/build-opentxs.sh
+++ b/ci/build-opentxs.sh
@@ -68,4 +68,4 @@ cd "${WORK}"
     -DOT_LUCRE_DEBUG=OFF \
     ${OT_OPTIONS} \
     "${SRC}"
-/usr/local/bin/cmake --build .
+/usr/local/bin/cmake --build . -- -k0

--- a/ci/opentxs-config.sh
+++ b/ci/opentxs-config.sh
@@ -269,6 +269,31 @@ elif [ "${OT_BUILD_VARIANT}" == "test08" ]; then
         -DOT_WITH_BLOCKCHAIN=OFF \
         -DOT_CRYPTO_USING_PACKETCRYPT=OFF \
         -DOT_ENABLE_RPC=ON"
+elif [ "${OT_BUILD_VARIANT}" == "tidy" ]; then
+    export OT_OPTIONS="
+        -DOT_CLANG_TIDY=ON \
+        -DOT_PCH=OFF \
+        -DCMAKE_UNITY_BUILD=OFF \
+        -DCMAKE_UNITY_BUILD_BATCH_SIZE=1 \
+        -DOPENTXS_BUILD_TESTS=ON \
+        -DOPENTXS_PEDANTIC_BUILD=ON \
+        -DOT_VALGRIND=ON \
+        -DOT_CRYPTO_SUPPORTED_KEY_RSA=ON \
+        -DOT_CRYPTO_SUPPORTED_KEY_SECP256K1=ON \
+        -DOT_CRYPTO_SUPPORTED_KEY_ED25519=ON \
+        -DOT_CRYPTO_USING_LIBSECP256K1=ON \
+        -DOT_CRYPTO_USING_OPENSSL=ON \
+        -DOT_DHT=ON \
+        -DOT_CASH_USING_LUCRE=ON \
+        -DOT_SCRIPT_USING_CHAI=ON \
+        -DOT_WITH_QT=ON \
+        -DOT_WITH_QML=ON \
+        -DOT_STORAGE_FS=ON \
+        -DOT_STORAGE_SQLITE=ON \
+        -DOT_STORAGE_LMDB=ON \
+        -DOT_WITH_BLOCKCHAIN=ON \
+        -DOT_CRYPTO_USING_PACKETCRYPT=ON \
+        -DOT_ENABLE_RPC=ON"
 else
     echo "Unknown build type: ${OT_BUILD_VARIANT}"
     return 1


### PR DESCRIPTION
- added new developer scripts
- added new docker image based on fedora 36
- cmake now continues to build even if errors are generated